### PR TITLE
feat(request): Add APIs to Request

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ struct UserBody: Encodable {}
 
 extension Request {
   static func login(_ body: UserBody) -> Self where Output == LoginResponse {
-    .post("login", body: .encodable(body))
+    .post("login", body: body)
   }
 }
 ```
@@ -86,13 +86,13 @@ extension Request {
   static func send(audio: URL) throws -> Self where Output == SendAudioResponse {
     var multipart = MultipartFormData()
     try multipart.add(url: audio, name: "define_your_name")
-    return .post("sendAudio", body: .multipart(multipart))
+    return .post("sendAudio", body: multipart)
   }
 
   static func send(audio: Data) throws -> Self where Output == SendAudioResponse {
     var multipart = MultipartFormData()
     try multipart.add(data: data, name: "your_name", fileName: "your_fileName", mimeType: "right_mimeType")
-    return .post("sendAudio", body: .multipart(multipart))
+    return .post("sendAudio", body: multipart)
   }
 }
 ```
@@ -107,7 +107,7 @@ extension Request {
     var multipart = MultipartFormData()
     try multipart.add(url: audio, name: "define_your_name")
     try multipart.add(data: image, name: "your_name", fileName: "your_fileName", mimeType: "right_mimeType")
-    return .post("sendAudioImage", body: .multipart(multipart))
+    return .post("sendAudioImage", body: multipart)
   }
 }
 ```

--- a/Sources/SimpleHTTP/Request/Endpoint.swift
+++ b/Sources/SimpleHTTP/Request/Endpoint.swift
@@ -21,9 +21,9 @@ import Foundation
 ///
 /// let user: Endpoint = .myEndpoints.user
 /// ```
-public struct Endpoint: Equatable, ExpressibleByStringLiteral {
+public struct Endpoint: Equatable, ExpressibleByStringLiteral, ExpressibleByStringInterpolation {
     /// relative path
-    let path: String
+    public let path: String
 
     init(path: String) {
         self.path = path
@@ -31,6 +31,10 @@ public struct Endpoint: Equatable, ExpressibleByStringLiteral {
 
     public init(stringLiteral value: StringLiteralType) {
         self.init(path: value)
+    }
+    
+    public init(stringInterpolation: DefaultStringInterpolation) {
+        self.init(path: stringInterpolation.description)
     }
 }
 

--- a/Sources/SimpleHTTP/Request/Endpoint.swift
+++ b/Sources/SimpleHTTP/Request/Endpoint.swift
@@ -36,5 +36,9 @@ public struct Endpoint: Equatable, ExpressibleByStringLiteral, ExpressibleByStri
     public init(stringInterpolation: DefaultStringInterpolation) {
         self.init(path: stringInterpolation.description)
     }
+    
+    public static func ==(lhs: Endpoint, rhs: String) -> Bool {
+        lhs.path == rhs
+    }
 }
 

--- a/Sources/SimpleHTTP/Request/Endpoint.swift
+++ b/Sources/SimpleHTTP/Request/Endpoint.swift
@@ -32,9 +32,5 @@ public struct Endpoint: Equatable, ExpressibleByStringLiteral {
     public init(stringLiteral value: StringLiteralType) {
         self.init(path: value)
     }
-
-    public static func ==(lhs: Endpoint, rhs: String) -> Bool {
-        lhs.path == rhs
-    }
 }
 

--- a/Sources/SimpleHTTP/Request/Request+URLRequest.swift
+++ b/Sources/SimpleHTTP/Request/Request+URLRequest.swift
@@ -24,6 +24,7 @@ extension Request {
         var urlRequest = try URLRequest(url: URL(from: self))
         
         urlRequest.httpMethod = method.rawValue.uppercased()
+        urlRequest.cachePolicy = cachePolicy
         urlRequest.setHeaders(headers)
         
         if let body = body {

--- a/Sources/SimpleHTTP/Request/Request.swift
+++ b/Sources/SimpleHTTP/Request/Request.swift
@@ -4,6 +4,7 @@ public enum Method: String {
     case get
     case post
     case put
+    case patch
     case delete
 }
 
@@ -29,46 +30,41 @@ public struct Request<Output> {
         self.init(endpoint: endpoint, method: .get, query: query, body: nil)
     }
     
-    /// Creates a request suitable for a HTTP POST with an optional `Body`
-    public static func post(_ endpoint: Endpoint, body: Body?, query: [String: QueryParam] = [:])
-    -> Self {
-        self.init(endpoint: endpoint, method: .post, query: query, body: body)
-    }
-    
     /// Creates a request suitable for a HTTP POST with a `Encodable` body
-    public static func post(_ endpoint: Endpoint, body: Encodable, query: [String: QueryParam] = [:])
+    public static func post(_ endpoint: Endpoint, body: Encodable?, query: [String: QueryParam] = [:])
     -> Self {
-        self.post(endpoint, body: .encodable(body), query: query)
+        self.init(endpoint: endpoint, method: .post, query: query, body: body.map(Body.encodable))
     }
     
     /// Creates a request suitable for a HTTP POST with a `MultipartFormData` body
-    public static func post(_ endpoint: Endpoint, body: MultipartFormData, query: [String: QueryParam] = [:])
+    @_disfavoredOverload
+    public static func post(_ endpoint: Endpoint, body: MultipartFormData?, query: [String: QueryParam] = [:])
     -> Self {
-        self.post(endpoint, body: .multipart(body), query: query)
-    }
-    
-    /// Creates a request suitable for a HTTP PUT with a `Body` body.
-    /// Default implementation does not allow for sending nil body. If you need such a case extend Request with your
-    /// own init method
-    public static func put(_ endpoint: Endpoint, body: Body, query: [String: QueryParam] = [:])
-    -> Self {
-        self.init(endpoint: endpoint, method: .put, query: query, body: body)
+        self.init(endpoint: endpoint, method: .post, query: query, body: body.map(Body.multipart))
     }
     
     /// Creates a request suitable for a HTTP PUT with a `Encodable` body
-    /// Default implementation does not allow for sending nil body. If you need such a case extend Request with your
-    /// own init method
     public static func put(_ endpoint: Endpoint, body: Encodable, query: [String: QueryParam] = [:])
     -> Self {
-        self.put(endpoint, body: .encodable(body), query: query)
+        self.init(endpoint: endpoint, method: .put, query: query, body: .encodable(body))
     }
     
     /// Creates a request suitable for a HTTP PUT with a `MultipartFormData` body
-    ///  Default implementation does not allow for sending nil body. If you need such a case extend Request with your
-    /// own init method
     public static func put(_ endpoint: Endpoint, body: MultipartFormData, query: [String: QueryParam] = [:])
     -> Self {
-        self.put(endpoint, body: .multipart(body), query: query)
+        self.init(endpoint: endpoint, method: .put, query: query, body: .multipart(body))
+    }
+    
+    /// Creates a request suitable for a HTTP PATCH with a `Encodable` body
+    public static func patch(_ endpoint: Endpoint, body: Encodable, query: [String: QueryParam] = [:])
+    -> Self {
+        self.init(endpoint: endpoint, method: .patch, query: query, body: .encodable(body))
+    }
+    
+    /// Creates a request suitable for a HTTP PATCH with a `MultipartFormData` body
+    public static func patch(_ endpoint: Endpoint, body: MultipartFormData, query: [String: QueryParam] = [:])
+    -> Self {
+        self.init(endpoint: endpoint, method: .patch, query: query, body: .multipart(body))
     }
     
     /// Creates a request suitable for a HTTP DELETE
@@ -80,7 +76,7 @@ public struct Request<Output> {
     
     /// Creates a Request.
     ///
-    /// Use this init only if default provided static initializers (`.get`, `.post`, `.put`, `.delete`) do not suit your needs.
+    /// Use this init only if default provided static initializers (`.get`, `.post`, `.put`, `patch`, `.delete`) do not suit your needs.
     public init(endpoint: Endpoint, method: Method, query: [String: QueryParam], body: Body?) {
         self.endpoint = endpoint
         self.method = method

--- a/Sources/SimpleHTTP/Request/Request.swift
+++ b/Sources/SimpleHTTP/Request/Request.swift
@@ -21,6 +21,7 @@ public struct Request<Output> {
     public let method: Method
     public let body: Body?
     public let query: [String: QueryParam]
+    public private(set) var cachePolicy: URLRequest.CachePolicy = .useProtocolCachePolicy
     public private(set) var headers: HTTPHeaderFields = [:]
     
     /// Creates a request suitable for a HTTP GET
@@ -47,7 +48,7 @@ public struct Request<Output> {
     }
     
     /// Creates a request suitable for a HTTP PUT with a `Body` body
-    public static func put(_ endpoint: Endpoint, body: Body, query: [String: QueryParam] = [:])
+    public static func put(_ endpoint: Endpoint, body: Body?, query: [String: QueryParam] = [:])
     -> Self {
         self.init(endpoint: endpoint, method: .put, query: query, body: body)
     }
@@ -76,11 +77,20 @@ public struct Request<Output> {
         self.query = query
     }
     
-    /// add headers to the request
+    /// Adds headers to the request
     public func headers(_ newHeaders: [HTTPHeader: String]) -> Self {
         var request = self
         
         request.headers.merge(newHeaders) { $1 }
+        
+        return request
+    }
+    
+    /// Configures request cache policy
+    public func cachePolicy(_ policy: URLRequest.CachePolicy) -> Self {
+        var request = self
+        
+        request.cachePolicy = policy
         
         return request
     }

--- a/Sources/SimpleHTTP/Request/Request.swift
+++ b/Sources/SimpleHTTP/Request/Request.swift
@@ -12,11 +12,10 @@ public enum Body {
     case multipart(MultipartFormData)
 }
 
-/// A Http request expecting an `Output` response
+/// A HTTP request safely typed for an `Output` response
 ///
 /// Highly inspired by https://swiftwithmajid.com/2021/02/10/building-type-safe-networking-in-swift/
 public struct Request<Output> {
-    
     /// request relative endpoint
     public let endpoint: Endpoint
     public let method: Method
@@ -24,20 +23,48 @@ public struct Request<Output> {
     public let query: [String: QueryParam]
     public private(set) var headers: HTTPHeaderFields = [:]
     
+    /// Creates a request suitable for a HTTP GET
     public static func get(_ endpoint: Endpoint, query: [String: QueryParam] = [:]) -> Self {
         self.init(endpoint: endpoint, method: .get, query: query, body: nil)
     }
     
+    /// Creates a request suitable for a HTTP POST with an optional `Body`
     public static func post(_ endpoint: Endpoint, body: Body?, query: [String: QueryParam] = [:])
     -> Self {
         self.init(endpoint: endpoint, method: .post, query: query, body: body)
     }
     
+    /// Creates a request suitable for a HTTP POST with a `Encodable` body
+    public static func post(_ endpoint: Endpoint, body: Encodable, query: [String: QueryParam] = [:])
+    -> Self {
+        self.post(endpoint, body: .encodable(body), query: query)
+    }
+    
+    /// Creates a request suitable for a HTTP POST with a `MultipartFormData` body
+    public static func post(_ endpoint: Endpoint, body: MultipartFormData, query: [String: QueryParam] = [:])
+    -> Self {
+        self.post(endpoint, body: .multipart(body), query: query)
+    }
+    
+    /// Creates a request suitable for a HTTP PUT with a `Body` body
     public static func put(_ endpoint: Endpoint, body: Body, query: [String: QueryParam] = [:])
     -> Self {
         self.init(endpoint: endpoint, method: .put, query: query, body: body)
     }
     
+    /// Creates a request suitable for a HTTP PUT with a `Encodable` body
+    public static func put(_ endpoint: Endpoint, body: Encodable, query: [String: QueryParam] = [:])
+    -> Self {
+        self.put(endpoint, body: .encodable(body), query: query)
+    }
+    
+    /// Creates a request suitable for a HTTP PUT with a `MultipartFormData` body
+    public static func put(_ endpoint: Endpoint, body: MultipartFormData, query: [String: QueryParam] = [:])
+    -> Self {
+        self.put(endpoint, body: .multipart(body), query: query)
+    }
+    
+    /// Creates a request suitable for a HTTP DELETE
     public static func delete(_ endpoint: Endpoint, query: [String: QueryParam] = [:]) -> Self {
         self.init(endpoint: endpoint, method: .delete, query: query, body: nil)
     }

--- a/Sources/SimpleHTTP/Request/Request.swift
+++ b/Sources/SimpleHTTP/Request/Request.swift
@@ -47,30 +47,41 @@ public struct Request<Output> {
         self.post(endpoint, body: .multipart(body), query: query)
     }
     
-    /// Creates a request suitable for a HTTP PUT with a `Body` body
-    public static func put(_ endpoint: Endpoint, body: Body?, query: [String: QueryParam] = [:])
+    /// Creates a request suitable for a HTTP PUT with a `Body` body.
+    /// Default implementation does not allow for sending nil body. If you need such a case extend Request with your
+    /// own init method
+    public static func put(_ endpoint: Endpoint, body: Body, query: [String: QueryParam] = [:])
     -> Self {
         self.init(endpoint: endpoint, method: .put, query: query, body: body)
     }
     
     /// Creates a request suitable for a HTTP PUT with a `Encodable` body
+    /// Default implementation does not allow for sending nil body. If you need such a case extend Request with your
+    /// own init method
     public static func put(_ endpoint: Endpoint, body: Encodable, query: [String: QueryParam] = [:])
     -> Self {
         self.put(endpoint, body: .encodable(body), query: query)
     }
     
     /// Creates a request suitable for a HTTP PUT with a `MultipartFormData` body
+    ///  Default implementation does not allow for sending nil body. If you need such a case extend Request with your
+    /// own init method
     public static func put(_ endpoint: Endpoint, body: MultipartFormData, query: [String: QueryParam] = [:])
     -> Self {
         self.put(endpoint, body: .multipart(body), query: query)
     }
     
     /// Creates a request suitable for a HTTP DELETE
+    /// Default implementation does not allow for sending a body. If you need such a case extend Request with your
+    /// own init method
     public static func delete(_ endpoint: Endpoint, query: [String: QueryParam] = [:]) -> Self {
         self.init(endpoint: endpoint, method: .delete, query: query, body: nil)
     }
     
-    private init(endpoint: Endpoint, method: Method, query: [String: QueryParam], body: Body?) {
+    /// Creates a Request.
+    ///
+    /// Use this init only if default provided static initializers (`.get`, `.post`, `.put`, `.delete`) do not suit your needs.
+    public init(endpoint: Endpoint, method: Method, query: [String: QueryParam], body: Body?) {
         self.endpoint = endpoint
         self.method = method
         self.body = body

--- a/Tests/SimpleHTTPTests/Request/RequestTests.swift
+++ b/Tests/SimpleHTTPTests/Request/RequestTests.swift
@@ -20,7 +20,7 @@ class RequestTests: XCTestCase {
     }
     
     func test_toURLRequest_encodeBody() throws {
-        let request = try Request<Void>.post(.test, body: .encodable(Body()))
+        let request = try Request<Void>.post(.test, body: Body())
             .toURLRequest(encoder: JSONEncoder(), relativeTo: baseURL)
         
         XCTAssertEqual(request.httpBody, try JSONEncoder().encode(Body()))
@@ -62,7 +62,7 @@ class RequestTests: XCTestCase {
     }
     
     func test_toURLRequest_bodyIsEncodable_fillContentTypeHeader() throws {
-        let request = try Request<Void>.post(.test, body: .encodable(Body()))
+        let request = try Request<Void>.post(.test, body: Body())
             .toURLRequest(encoder: JSONEncoder(), relativeTo: baseURL)
         
         XCTAssertEqual(request.allHTTPHeaderFields?["Content-Type"], "application/json")

--- a/Tests/SimpleHTTPTests/Request/RequestTests.swift
+++ b/Tests/SimpleHTTPTests/Request/RequestTests.swift
@@ -19,11 +19,20 @@ class RequestTests: XCTestCase {
         XCTAssertEqual(request.httpMethod, "POST")
     }
 
-    func test_toURLRequest_EncodeBody() throws {
+    func test_toURLRequest_encodeBody() throws {
       let request = try Request<Void>.post(.test, body: .encodable(Body()))
             .toURLRequest(encoder: JSONEncoder(), relativeTo: baseURL)
 
       XCTAssertEqual(request.httpBody, try JSONEncoder().encode(Body()))
+    }
+    
+    func test_toURLRequest_setCachePolicy() throws {
+        let request = try Request<Void>
+              .get(.test)
+              .cachePolicy(.returnCacheDataDontLoad)
+              .toURLRequest(encoder: JSONEncoder(), relativeTo: baseURL)
+
+        XCTAssertEqual(request.cachePolicy, .returnCacheDataDontLoad)
     }
 
     func test_toURLRequest_encodeMultipartBody() throws {
@@ -52,14 +61,14 @@ class RequestTests: XCTestCase {
       XCTAssertEqual(request.httpBody, body)
     }
 
-    func test_toURLRequest_bodyIsEncodable_FillDefaultHeaders() throws {
+    func test_toURLRequest_bodyIsEncodable_fillContentTypeHeader() throws {
       let request = try Request<Void>.post(.test, body: .encodable(Body()))
             .toURLRequest(encoder: JSONEncoder(), relativeTo: baseURL)
 
       XCTAssertEqual(request.allHTTPHeaderFields?["Content-Type"], "application/json")
     }
 
-    func test_toURLRequest_bodyIsMultipart_itFillDefaultHeaders() throws {
+    func test_toURLRequest_bodyIsMultipart_fillContentTypeHeader() throws {
       let boundary = "boundary"
       var multipart = MultipartFormData(boundary: boundary)
       let url = try url(forResource: "swift", withExtension: "png")

--- a/Tests/SimpleHTTPTests/Request/RequestTests.swift
+++ b/Tests/SimpleHTTPTests/Request/RequestTests.swift
@@ -18,67 +18,67 @@ class RequestTests: XCTestCase {
         
         XCTAssertEqual(request.httpMethod, "POST")
     }
-
+    
     func test_toURLRequest_encodeBody() throws {
-      let request = try Request<Void>.post(.test, body: .encodable(Body()))
+        let request = try Request<Void>.post(.test, body: .encodable(Body()))
             .toURLRequest(encoder: JSONEncoder(), relativeTo: baseURL)
-
-      XCTAssertEqual(request.httpBody, try JSONEncoder().encode(Body()))
+        
+        XCTAssertEqual(request.httpBody, try JSONEncoder().encode(Body()))
     }
     
     func test_toURLRequest_setCachePolicy() throws {
         let request = try Request<Void>
-              .get(.test)
-              .cachePolicy(.returnCacheDataDontLoad)
-              .toURLRequest(encoder: JSONEncoder(), relativeTo: baseURL)
-
+            .get(.test)
+            .cachePolicy(.returnCacheDataDontLoad)
+            .toURLRequest(encoder: JSONEncoder(), relativeTo: baseURL)
+        
         XCTAssertEqual(request.cachePolicy, .returnCacheDataDontLoad)
     }
-
+    
     func test_toURLRequest_encodeMultipartBody() throws {
-      let crlf = EncodingCharacters.crlf
-      let boundary = "boundary"
-      var multipart = MultipartFormData(boundary: boundary)
-      let url = try url(forResource: "swift", withExtension: "png")
-      let name = "swift"
-      try multipart.add(url: url, name: name)
-
-      let request = try Request<Void>.post(.test, body: .multipart(multipart))
+        let crlf = EncodingCharacters.crlf
+        let boundary = "boundary"
+        var multipart = MultipartFormData(boundary: boundary)
+        let url = try url(forResource: "swift", withExtension: "png")
+        let name = "swift"
+        try multipart.add(url: url, name: name)
+        
+        let request = try Request<Void>.post(.test, body: .multipart(multipart))
             .toURLRequest(encoder: JSONEncoder(), relativeTo: baseURL)
-
-      /// We can't use  `XCTAssertEqual(request.httpBody, try multipart.encode)`
-      /// The `encode` method is executed to fast and rase and error
-      var body = Data()
-      body.append(Boundary.data(for: .initial, boundary: boundary))
-      body.append(
-        Data((
-          "Content-Disposition: form-data; name=\"\(name)\"; filename=\"swift.png\"\(crlf)"
-            + "Content-Type: image/png\(crlf)\(crlf)"
-        ).utf8)
-      )
-      body.append(try Data(contentsOf: url))
-      body.append(Boundary.data(for: .final, boundary: boundary))
-      XCTAssertEqual(request.httpBody, body)
+        
+        /// We can't use  `XCTAssertEqual(request.httpBody, try multipart.encode)`
+        /// The `encode` method is executed to fast and rase and error
+        var body = Data()
+        body.append(Boundary.data(for: .initial, boundary: boundary))
+        body.append(
+            Data((
+                "Content-Disposition: form-data; name=\"\(name)\"; filename=\"swift.png\"\(crlf)"
+                + "Content-Type: image/png\(crlf)\(crlf)"
+            ).utf8)
+        )
+        body.append(try Data(contentsOf: url))
+        body.append(Boundary.data(for: .final, boundary: boundary))
+        XCTAssertEqual(request.httpBody, body)
     }
-
+    
     func test_toURLRequest_bodyIsEncodable_fillContentTypeHeader() throws {
-      let request = try Request<Void>.post(.test, body: .encodable(Body()))
+        let request = try Request<Void>.post(.test, body: .encodable(Body()))
             .toURLRequest(encoder: JSONEncoder(), relativeTo: baseURL)
-
-      XCTAssertEqual(request.allHTTPHeaderFields?["Content-Type"], "application/json")
+        
+        XCTAssertEqual(request.allHTTPHeaderFields?["Content-Type"], "application/json")
     }
-
+    
     func test_toURLRequest_bodyIsMultipart_fillContentTypeHeader() throws {
-      let boundary = "boundary"
-      var multipart = MultipartFormData(boundary: boundary)
-      let url = try url(forResource: "swift", withExtension: "png")
-      let name = "swift"
-      try multipart.add(url: url, name: name)
-
-      let request = try Request<Void>.post(.test, body: .multipart(multipart))
+        let boundary = "boundary"
+        var multipart = MultipartFormData(boundary: boundary)
+        let url = try url(forResource: "swift", withExtension: "png")
+        let name = "swift"
+        try multipart.add(url: url, name: name)
+        
+        let request = try Request<Void>.post(.test, body: .multipart(multipart))
             .toURLRequest(encoder: JSONEncoder(), relativeTo: baseURL)
-
-      XCTAssertEqual(request.allHTTPHeaderFields?["Content-Type"], HTTPContentType.multipart(boundary: multipart.boundary).value)
+        
+        XCTAssertEqual(request.allHTTPHeaderFields?["Content-Type"], HTTPContentType.multipart(boundary: multipart.boundary).value)
     }
     
 }

--- a/Tests/SimpleHTTPTests/Request/RequestTests.swift
+++ b/Tests/SimpleHTTPTests/Request/RequestTests.swift
@@ -20,10 +20,10 @@ class RequestTests: XCTestCase {
     }
     
     func test_toURLRequest_encodeBody() throws {
-        let request = try Request<Void>.post(.test, body: Body())
+        let request = try Request<Void>.post(.test, body: BodyMock())
             .toURLRequest(encoder: JSONEncoder(), relativeTo: baseURL)
         
-        XCTAssertEqual(request.httpBody, try JSONEncoder().encode(Body()))
+        XCTAssertEqual(request.httpBody, try JSONEncoder().encode(BodyMock()))
     }
     
     func test_toURLRequest_setCachePolicy() throws {
@@ -43,7 +43,7 @@ class RequestTests: XCTestCase {
         let name = "swift"
         try multipart.add(url: url, name: name)
         
-        let request = try Request<Void>.post(.test, body: .multipart(multipart))
+        let request = try Request<Void>.post(.test, body: multipart)
             .toURLRequest(encoder: JSONEncoder(), relativeTo: baseURL)
         
         /// We can't use  `XCTAssertEqual(request.httpBody, try multipart.encode)`
@@ -62,7 +62,7 @@ class RequestTests: XCTestCase {
     }
     
     func test_toURLRequest_bodyIsEncodable_fillContentTypeHeader() throws {
-        let request = try Request<Void>.post(.test, body: Body())
+        let request = try Request<Void>.post(.test, body: BodyMock())
             .toURLRequest(encoder: JSONEncoder(), relativeTo: baseURL)
         
         XCTAssertEqual(request.allHTTPHeaderFields?["Content-Type"], "application/json")
@@ -75,7 +75,7 @@ class RequestTests: XCTestCase {
         let name = "swift"
         try multipart.add(url: url, name: name)
         
-        let request = try Request<Void>.post(.test, body: .multipart(multipart))
+        let request = try Request<Void>.post(.test, body: multipart)
             .toURLRequest(encoder: JSONEncoder(), relativeTo: baseURL)
         
         XCTAssertEqual(request.allHTTPHeaderFields?["Content-Type"], HTTPContentType.multipart(boundary: multipart.boundary).value)
@@ -83,6 +83,6 @@ class RequestTests: XCTestCase {
     
 }
 
-private struct Body: Encodable {
+private struct BodyMock: Encodable {
     
 }


### PR DESCRIPTION
Adds (or re-add) apis to Request:

- Adds methods to directly post/put `Encodable` and `MultipartFormData` and remove methods accepting `Body`
- Makes `init` public so people can implement specific cases if needed (like a delete with a body)
- Adds `cachePolicy`
- Adds `PATCH`
- Creates `Endpoint` from interpolation string