### PR TITLE
fix(foundation): Make Authorization header available

### DIFF
--- a/Sources/SimpleHTTPFoundation/HTTP/HTTPHeader.swift
+++ b/Sources/SimpleHTTPFoundation/HTTP/HTTPHeader.swift
@@ -15,13 +15,13 @@ public struct HTTPHeader: Hashable, ExpressibleByStringLiteral {
 extension HTTPHeader {
     public static let accept: Self = "Accept"
     public static let authentication: Self = "Authentication"
+    public static let authorization: Self = "Authorization"
     public static let contentType: Self = "Content-Type"
     public static var contentDisposition: Self = "Content-Disposition"
 }
 
 @available(*, unavailable, message: "This is a reserved header. See https://developer.apple.com/documentation/foundation/nsurlrequest#1776617")
 extension HTTPHeader {
-    public static let authorization: Self = "Authorization"
     public static let connection: Self = "Connection"
     public static let contentLength: Self = "Content-Length"
     public static let host: Self = "Host"


### PR DESCRIPTION
Authorization header was locked, following https://developer.apple.com/documentation/foundation/nsurlrequest#1776617. But it's actually an important header used by OAuth & co so unlock it.

No effect on other heards