### PR TITLE
fix(foundation): Fixed crash in URLSession.data(for:)

### DIFF
--- a/Sources/SimpleHTTPFoundation/Foundation/URLSession+Async.swift
+++ b/Sources/SimpleHTTPFoundation/Foundation/URLSession+Async.swift
@@ -6,7 +6,7 @@ extension URLSession {
         try await withCheckedThrowingContinuation { promise in
             self.dataTask(with: urlRequest) { data, response, error in
                 if let error = error {
-                    promise.resume(throwing: error)
+                    return promise.resume(throwing: error)
                 }
                 
                 guard let data = data, let response = response else {


### PR DESCRIPTION
Fixed a crash that could happen when URLSession.data was returning an error: The continuation closure was terminated too many times.