### PR TITLE
feat(interceptor): Make public rescue API async

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -9,6 +9,7 @@ excluded:
 disabled_rules:
   - statement_position
   - type_name
+  - trailing_newline
 
 opt_in_rules:
   - closure_end_indentation

--- a/Sources/SimpleHTTP/Interceptor/CompositeInterceptor.swift
+++ b/Sources/SimpleHTTP/Interceptor/CompositeInterceptor.swift
@@ -21,14 +21,14 @@ extension CompositeInterceptor: Interceptor {
         }
     }
 
-    public func rescueRequest<Output>(_ request: Request<Output>, error: Error) -> AnyPublisher<Void, Error>? {
-        let publishers = compactMap { $0.rescueRequest(request, error: error) }
-
-        guard !publishers.isEmpty else {
-            return nil
+    public func shouldRescueRequest<Output>(_ request: Request<Output>, error: Error) async throws -> Bool {
+        for interceptor in interceptors {
+            if try await interceptor.shouldRescueRequest(request, error: error) {
+                return true
+            }
         }
 
-        return Publishers.MergeMany(publishers).eraseToAnyPublisher()
+        return false
     }
 
     public func adaptOutput<Output>(_ response: Output, for request: Request<Output>) throws -> Output {

--- a/Sources/SimpleHTTP/Interceptor/CompositeInterceptor.swift
+++ b/Sources/SimpleHTTP/Interceptor/CompositeInterceptor.swift
@@ -22,10 +22,8 @@ extension CompositeInterceptor: Interceptor {
     }
 
     public func shouldRescueRequest<Output>(_ request: Request<Output>, error: Error) async throws -> Bool {
-        for interceptor in interceptors {
-            if try await interceptor.shouldRescueRequest(request, error: error) {
-                return true
-            }
+        for interceptor in interceptors where try await interceptor.shouldRescueRequest(request, error: error) {
+            return true
         }
 
         return false

--- a/Sources/SimpleHTTP/Interceptor/Interceptor.swift
+++ b/Sources/SimpleHTTP/Interceptor/Interceptor.swift
@@ -11,7 +11,7 @@ public protocol RequestInterceptor {
     /// catch and retry a failed request
     /// - Returns: nil if the request should not be retried. Otherwise a publisher that will be executed before
     /// retrying the request
-    func rescueRequest<Output>(_ request: Request<Output>, error: Error) -> AnyPublisher<Void, Error>?
+    func shouldRescueRequest<Output>(_ request: Request<Output>, error: Error) async throws -> Bool
 }
 
 /// a protocol intercepting a session response
@@ -24,33 +24,4 @@ public protocol ResponseInterceptor {
     /// Notify of received response for `request`
     /// - Parameter request: the request that was sent to the server
     func receivedResponse<Output>(_ result: Result<Output, Error>, for request: Request<Output>)
-}
-
-extension RequestInterceptor {
-    func shouldRescueRequest<Output>(_ request: Request<Output>, error: Error) async throws -> Bool {
-        var cancellable: Set<AnyCancellable> = []
-        let onCancel = { cancellable.removeAll() }
-
-        guard let rescuePublisher = rescueRequest(request, error: error) else {
-            return false
-        }
-
-        return try await withTaskCancellationHandler(
-            handler: { onCancel() },
-            operation: {
-                try await withCheckedThrowingContinuation { continuation in
-                    rescuePublisher
-                        .sink(
-                            receiveCompletion: {
-                                if case let .failure(error) = $0 {
-                                    return continuation.resume(throwing: error)
-                                }
-                            },
-                            receiveValue: { _ in
-                                continuation.resume(returning: true)
-                            })
-                        .store(in: &cancellable)
-                }
-            })
-    }
 }

--- a/Tests/SimpleHTTPTests/Interceptor/CompositeInterceptorTests.swift
+++ b/Tests/SimpleHTTPTests/Interceptor/CompositeInterceptorTests.swift
@@ -1,0 +1,40 @@
+import XCTest
+import SimpleHTTP
+
+class CompositeInterceptorTests: XCTestCase {
+    func test_shouldRescue_moreThanOneInterceptorRescue_callFirstOneOnly() async throws {
+        let interceptors: CompositeInterceptor = [
+            InterceptorStub(shouldRequestMock: { _ in false }),
+            InterceptorStub(shouldRequestMock: { _ in true }),
+            InterceptorStub(shouldRequestMock: { _ in
+                XCTFail("should not be called because request was already rescued")
+                return true
+            })
+        ]
+
+        let result = try await interceptors.shouldRescueRequest(Request<Void>.get("/test"), error: HTTPError(statusCode: 888))
+
+        XCTAssertTrue(result)
+    }
+}
+
+private struct InterceptorStub: Interceptor {
+    var shouldRequestMock: (Error) throws -> Bool = { _ in false }
+
+    func shouldRescueRequest<Output>(_ request: Request<Output>, error: Error) async throws -> Bool {
+        try shouldRequestMock(error)
+    }
+
+    func adaptRequest<Output>(_ request: Request<Output>) -> Request<Output> {
+        request
+    }
+
+    func adaptOutput<Output>(_ output: Output, for request: Request<Output>) throws -> Output {
+        output
+    }
+
+    func receivedResponse<Output>(_ result: Result<Output, Error>, for request: Request<Output>) {
+
+    }
+
+}

--- a/Tests/SimpleHTTPTests/Interceptor/CompositeInterceptorTests.swift
+++ b/Tests/SimpleHTTPTests/Interceptor/CompositeInterceptorTests.swift
@@ -12,7 +12,8 @@ class CompositeInterceptorTests: XCTestCase {
             })
         ]
 
-        let result = try await interceptors.shouldRescueRequest(Request<Void>.get("/test"), error: HTTPError(statusCode: 888))
+        let result = try await interceptors
+            .shouldRescueRequest(Request<Void>.get("/test"), error: HTTPError(statusCode: 888))
 
         XCTAssertTrue(result)
     }

--- a/Tests/SimpleHTTPTests/Session/SessionTests.swift
+++ b/Tests/SimpleHTTPTests/Session/SessionTests.swift
@@ -47,7 +47,7 @@ class SessionAsyncTests: XCTestCase {
 
         interceptor.rescueRequestErrorMock = { _ in
             isRescued.toggle()
-            return Just(()).setFailureType(to: Error.self).eraseToAnyPublisher()
+            return true
         }
 
         _ = try await session.response(for: .void())
@@ -120,7 +120,7 @@ private extension Request {
 }
 
 private class InterceptorStub: Interceptor {
-    var rescueRequestErrorMock: ((Error) -> AnyPublisher<Void, Error>?)?
+    var rescueRequestErrorMock: (Error) throws -> Bool = { _ in false }
     var receivedResponseMock: ((Any, Any) -> Void)?
     var adaptResponseMock: ((Any, Any) throws -> Any)?
 
@@ -128,8 +128,8 @@ private class InterceptorStub: Interceptor {
         request
     }
 
-    func rescueRequest<Output>(_ request: Request<Output>, error: Error) -> AnyPublisher<Void, Error>? {
-        rescueRequestErrorMock?(error)
+    func shouldRescueRequest<Output>(_ request: Request<Output>, error: Error) async throws -> Bool {
+        try rescueRequestErrorMock(error)
     }
 
     func adaptOutput<Output>(_ output: Output, for request: Request<Output>) throws -> Output {


### PR DESCRIPTION
Migrate `rescue` API to async and rename it `shouldRescue`.

This also fix a potential crash in previous API if publisher was sending more than one value leading to crash with message "swift continuation misuse: rescue leaked its continuation"