### PR TITLE
fix(Multipart): Create InputStream only when the body is filled

### DIFF
--- a/Sources/SimpleHTTP/MultipartForm/MultipartFormData.swift
+++ b/Sources/SimpleHTTP/MultipartForm/MultipartFormData.swift
@@ -48,15 +48,27 @@ enum Boundary {
 
 struct BodyPart {
     let headers: [Header]
-    let stream: InputStream
     let length: Int
+    let stream: () throws -> InputStream
+
     var hasInitialBoundary = false
     var hasFinalBoundary = false
 
-    init(headers: [Header], stream: InputStream, length: Int) {
+    init(headers: [Header], url: URL, length: Int) {
         self.headers = headers
-        self.stream = stream
+        self.stream = {
+            guard let stream = InputStream(url: url) else {
+                throw MultipartFormData.Error.inputStreamCreationFailed(url)
+            }
+            return stream
+        }
         self.length = length
+    }
+
+    init(headers: [Header], data: Data) {
+        self.headers = headers
+        self.stream = { InputStream(data: data) }
+        self.length = data.count
     }
 }
 
@@ -126,12 +138,7 @@ public struct MultipartFormData {
         }
 
         let length = fileSize.intValue
-
-        guard let stream = InputStream(url: url) else {
-            throw MultipartFormData.Error.inputStreamCreationFailed(url)
-        }
-
-        bodyParts.append(BodyPart(headers: headers, stream: stream, length: length))
+        bodyParts.append(BodyPart(headers: headers, url: url, length: length))
     }
 
     /// Creates a body part from the data and add it to the instance.
@@ -150,10 +157,8 @@ public struct MultipartFormData {
     ///   - mimeType: MIME type associated to the data in the `Content-Type` HTTPHeader.
     public mutating func add(data: Data, name: String, fileName: String? = nil, mimeType: String? = nil) {
         let headers = defineBodyPartHeader(name: name, fileName: fileName, mimeType: mimeType)
-        let stream = InputStream(data: data)
-        let length = data.count
 
-        bodyParts.append(BodyPart(headers: headers, stream: stream, length: length))
+        bodyParts.append(BodyPart(headers: headers, data: data))
     }
 
     private func defineBodyPartHeader(name: String, fileName: String?, mimeType: String?) -> [Header] {

--- a/Sources/SimpleHTTP/MultipartForm/MultipartFormData.swift
+++ b/Sources/SimpleHTTP/MultipartForm/MultipartFormData.swift
@@ -54,21 +54,24 @@ struct BodyPart {
     var hasInitialBoundary = false
     var hasFinalBoundary = false
 
-    init(headers: [Header], url: URL, length: Int) {
+    private init(headers: [Header], stream: @escaping () throws -> InputStream, length: Int) {
         self.headers = headers
-        self.stream = {
+        self.length = length
+        self.stream = stream
+    }
+
+    init(headers: [Header], url: URL, length: Int) {
+        let stream = {
             guard let stream = InputStream(url: url) else {
                 throw MultipartFormData.Error.inputStreamCreationFailed(url)
             }
             return stream
         }
-        self.length = length
+        self.init(headers: headers, stream: stream, length: length)
     }
 
     init(headers: [Header], data: Data) {
-        self.headers = headers
-        self.stream = { InputStream(data: data) }
-        self.length = data.count
+        self.init(headers: headers, stream: { InputStream(data: data) }, length: data.count)
     }
 }
 

--- a/Sources/SimpleHTTP/MultipartForm/MultipartFormData.swift
+++ b/Sources/SimpleHTTP/MultipartForm/MultipartFormData.swift
@@ -61,7 +61,7 @@ struct BodyPart {
     }
 
     init(headers: [Header], url: URL, length: Int) {
-        let stream = {
+        let stream: () throws -> InputStream = {
             guard let stream = InputStream(url: url) else {
                 throw MultipartFormData.Error.inputStreamCreationFailed(url)
             }

--- a/Sources/SimpleHTTP/MultipartForm/MultipartFormDataEncoder.swift
+++ b/Sources/SimpleHTTP/MultipartForm/MultipartFormDataEncoder.swift
@@ -46,7 +46,7 @@ struct MultipartFormDataEncoder {
         }
 
         encoded.append(try encodeBodyPart(headers: bodyPart.headers))
-        encoded.append(try encodeBodyPart(stream: bodyPart.stream, length: bodyPart.length))
+        encoded.append(try encodeBodyPart(stream: bodyPart.stream(), length: bodyPart.length))
 
         if bodyPart.hasFinalBoundary {
             encoded.append(Boundary.data(for: .final, boundary: boundary))

--- a/Tests/SimpleHTTPTests/MultipartForm/MultipartFormDataEncoderTests.swift
+++ b/Tests/SimpleHTTPTests/MultipartForm/MultipartFormDataEncoderTests.swift
@@ -158,4 +158,18 @@ class MultipartFormDataEncoderTests: XCTestCase {
         XCTAssertEqual(encodedData, expectedData)
     }
 
+    func test_encode_encoreMultiPartFormDataTwice_notThrow() throws {
+        let boundary = "boundary"
+        var multipart = MultipartFormData(boundary: boundary)
+
+        let data = "I'm pjechris, Nice to meet you"
+        let name1 = "data"
+        multipart.add(data: Data(data.utf8), name: name1)
+
+        var encoder = MultipartFormDataEncoder(body: multipart)
+        _ = try encoder.encode()
+
+        XCTAssertNoThrow(_ = try encoder.encode())
+    }
+
 }


### PR DESCRIPTION
InputStream can be open only once, so if a request is sent and receives an error, the second sending operation will failed because the InputStream was opened and cannot be open again.

Fix : Create the InputStream only when the request is encoded