### PR TITLE
fix lint issues

### DIFF
--- a/Sources/SimpleHTTP/Interceptor/CompositeInterceptor.swift
+++ b/Sources/SimpleHTTP/Interceptor/CompositeInterceptor.swift
@@ -18,7 +18,7 @@ extension CompositeInterceptor: Interceptor {
     public func adaptRequest<Output>(_ request: Request<Output>) async -> Request<Output> {
         var request = request
         for interceptor in interceptors {
-          request = await interceptor.adaptRequest(request)
+            request = await interceptor.adaptRequest(request)
         }
 
         return request

--- a/Tests/SimpleHTTPTests/Response/URLDataResponseTests.swift
+++ b/Tests/SimpleHTTPTests/Response/URLDataResponseTests.swift
@@ -13,7 +13,7 @@ class URLDataResponseTests: XCTestCase {
         let response = URLDataResponse(data: Data(), response: HTTPURLResponse.notFound)
         let transformer: DataErrorDecoder = { _ in
             XCTFail("transformer should not be called when data is empty")
-            throw NSError()
+            throw NSError(domain: "test", code: 0)
         }
 
         XCTAssertThrowsError(try response.validate(errorDecoder: transformer))


### PR DESCRIPTION
Following linter issues are fixed with this PR
- Sources/SimpleHTTP/Interceptor/CompositeInterceptor.swift:21:1: warning: Indentation Width Violation: Code should be indented using one tab or 4 spaces (indentation_width)
- Tests/SimpleHTTPTests/Response/URLDataResponseTests.swift:16:19: warning: Discouraged Direct Initialization Violation: Discouraged direct initialization of types that can be harmful (discouraged_direct_init)