### PR TITLE
feat(interceptor): Allow to throw when adapting

### DIFF
--- a/Sources/SimpleHTTP/Interceptor/CompositeInterceptor.swift
+++ b/Sources/SimpleHTTP/Interceptor/CompositeInterceptor.swift
@@ -14,10 +14,10 @@ public struct CompositeInterceptor: ExpressibleByArrayLiteral, Sequence {
 }
 
 extension CompositeInterceptor: Interceptor {
-    public func adaptRequest<Output>(_ request: Request<Output>) async -> Request<Output> {
+    public func adaptRequest<Output>(_ request: Request<Output>) async throws -> Request<Output> {
         var request = request
         for interceptor in interceptors {
-            request = await interceptor.adaptRequest(request)
+            request = try await interceptor.adaptRequest(request)
         }
 
         return request

--- a/Sources/SimpleHTTP/Interceptor/Interceptor.swift
+++ b/Sources/SimpleHTTP/Interceptor/Interceptor.swift
@@ -5,7 +5,7 @@ public typealias Interceptor = RequestInterceptor & ResponseInterceptor
 /// a protocol intercepting a session request
 public protocol RequestInterceptor {
     /// Should be called before making the request to provide modifications to `request`
-    func adaptRequest<Output>(_ request: Request<Output>) async -> Request<Output>
+    func adaptRequest<Output>(_ request: Request<Output>) async throws -> Request<Output>
 
     /// catch and retry a failed request
     /// - Returns: nil if the request should not be retried. Otherwise a publisher that will be executed before

--- a/Sources/SimpleHTTP/Session/Session.swift
+++ b/Sources/SimpleHTTP/Session/Session.swift
@@ -66,7 +66,7 @@ public class Session {
 
 extension Session {
     private func dataPublisher<Output>(for request: Request<Output>) async throws -> Response<Output> {
-        let modifiedRequest = await config.interceptor.adaptRequest(request)
+        let modifiedRequest = try await config.interceptor.adaptRequest(request)
         let urlRequest = try modifiedRequest
             .toURLRequest(encoder: config.encoder, relativeTo: baseURL, accepting: config.decoder)
 


### PR DESCRIPTION
Allow adapter to throw when transforming the request. This could be useful to prevent a request from happening.

In case of throwing:
- The request won't be calling `shouldRescue` interceptor method
- `receivedResponse` won't be called either